### PR TITLE
Fix bug that note actions and links are hidden

### DIFF
--- a/src/sass/components/_elements.scss
+++ b/src/sass/components/_elements.scss
@@ -85,6 +85,8 @@ a.collapsible.collapsed,
 .contextual {
   float: right;
   cursor: default;
+  position: relative;
+  z-index: 1;
 
   input,
   select {
@@ -99,6 +101,10 @@ a.collapsible.collapsed,
       margin-left: $padding-small-vertical;
     }
   }
+}
+
+.journal .contextual {
+  padding: 8px 15px;
 }
 
 

--- a/src/sass/components/_issue.scss
+++ b/src/sass/components/_issue.scss
@@ -579,7 +579,7 @@ div.thumbnails {
 }
 
 .journal-link {
-  float: right;
+  /* float: right; */
 }
 
 span.private {


### PR DESCRIPTION
Actions and links for notes should be visible on the top right position of notes.
But that were hidden for theme css on my redmine.