### PR TITLE
Invalid position of pagination with large image attachment

### DIFF
--- a/src/sass/components/_elements.scss
+++ b/src/sass/components/_elements.scss
@@ -114,13 +114,13 @@ img {
 
 .filecontent-container {
   position: relative;
-  margin-bottom: 20px;
   min-height: 200px;
+  margin-bottom: 20px;
 }
 .filecontent-container > .filecontent {
   position: absolute;
-  max-height: 100%;
   max-width: 100%;
+  max-height: 100%;
 }
 
 //== Responsive autoscroll

--- a/src/sass/components/_elements.scss
+++ b/src/sass/components/_elements.scss
@@ -108,6 +108,20 @@ a.collapsible.collapsed,
   // stylelint-enable declaration-no-important
 }
 
+img {
+  image-orientation: from-image;
+}
+
+.filecontent-container {
+  position: relative;
+  margin-bottom: 20px;
+  min-height: 200px;
+}
+.filecontent-container > .filecontent {
+  position: absolute;
+  max-height: 100%;
+  max-width: 100%;
+}
 
 //== Responsive autoscroll
 //


### PR DESCRIPTION
When I show attachment image from issue page, the position of pagination is invalid like following.
It's no problem if I use theme of **Alternate**.
![purplemin2](https://user-images.githubusercontent.com/378981/62906685-b88f4d80-bdaa-11e9-97f4-6dbff082564f.png)
