### PR TITLE
Fix url.indexOf is Not a Function Error

### DIFF
--- a/src/javascripts/modules/SidebarToggler.js
+++ b/src/javascripts/modules/SidebarToggler.js
@@ -44,7 +44,7 @@ PurpleMine.SidebarToggler = (function () {
 
     // Fix issue with context menu position
     if (this.$main.css('position') === 'relative') {
-      $(window).load(function () {
+      $(window).on("load",function () {
         $('#context-menu').appendTo('#wrapper3')
       })
     }


### PR DESCRIPTION
The sidebar toogler isn't working with newer [jquery versions](https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed)