### PR TITLE
Increase top menu elements margin.

### DIFF
--- a/src/sass/components/_top.scss
+++ b/src/sass/components/_top.scss
@@ -76,7 +76,7 @@
   }
 
   li {
-    margin: 0 .5em 0 0;
+    margin: 0 .8em 0 0;
     padding: 0;
     float: left;
     list-style-type: none;


### PR DESCRIPTION
Increase top menu margin between top menu elements, because they are mixing with each other and are not readable.